### PR TITLE
fix(ci): replace deprecated app-id with client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - name: 📥 Checkout repository
@@ -219,7 +219,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: fulviofreitas
           repositories: homebrew-eeroctl


### PR DESCRIPTION
## Summary
- Replaces deprecated `app-id` input with `client-id` in both `actions/create-github-app-token@v3` usages in `release.yml`
- Fixes the deprecation warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

## Test plan
- [ ] Verify the release workflow runs without deprecation warnings