### PR TITLE
feat(profile): add create/rename/delete + mutation regression suite

### DIFF
--- a/src/eeroctl/commands/profile.py
+++ b/src/eeroctl/commands/profile.py
@@ -3,6 +3,9 @@
 Commands:
 - eero profile list: List all profiles
 - eero profile show: Show profile details
+- eero profile create: Create a new profile
+- eero profile rename: Rename a profile
+- eero profile delete: Delete a profile
 - eero profile pause: Pause a profile
 - eero profile unpause: Unpause a profile
 - eero profile apps: App blocking management
@@ -56,6 +59,9 @@ def profile_group(ctx: click.Context) -> None:
     Commands:
       list     - List all profiles
       show     - Show profile details
+      create   - Create a new profile
+      rename   - Rename a profile
+      delete   - Delete a profile
       pause    - Pause internet access
       unpause  - Resume internet access
       apps     - Blocked apps management
@@ -65,6 +71,9 @@ def profile_group(ctx: click.Context) -> None:
     Examples:
       eero profile list
       eero profile show "Kids"
+      eero profile create Kids
+      eero profile rename Kids Schoolkids
+      eero profile delete Kids --force
       eero profile pause "Kids" --duration 30m
       eero profile apps block "Kids" tiktok
     """
@@ -197,6 +206,182 @@ def profile_show(
                 print_profile_details(profile, detail_level=detail)
 
         await run_with_client(get_profile)
+
+    asyncio.run(run_cmd())
+
+
+@profile_group.command(name="create")
+@click.argument("name")
+@output_option
+@network_option
+@click.pass_context
+def profile_create(
+    ctx: click.Context, name: str, output: Optional[str], network_id: Optional[str]
+) -> None:
+    """Create a new profile.
+
+    \b
+    Arguments:
+      NAME  Name for the new profile
+    """
+    cli_ctx = apply_options(ctx, output=output, network_id=network_id)
+    console = cli_ctx.console
+
+    async def run_cmd() -> None:
+        async def create_profile(client: EeroClient) -> None:
+            with cli_ctx.status("Creating profile..."):
+                result = await client.create_profile(name, cli_ctx.network_id)
+
+            meta = result.get("meta", {}) if isinstance(result, dict) else {}
+            if meta.get("code") == 200:
+                profile = normalize_profile(extract_data(result))
+
+                if cli_ctx.is_structured_output():
+                    cli_ctx.render_structured(profile, "eero.profile.create/v1")
+                elif cli_ctx.is_list_output():
+                    from ..formatting.profile import get_profile_list_data
+
+                    list_data = get_profile_list_data(profile)
+                    for key, value in list_data.items():
+                        print(f"{key}: {value if value is not None else '-'}")
+                else:
+                    console.print(
+                        f"[bold green]Profile created:[/bold green] "
+                        f"{profile.get('name') or name} ({profile.get('id') or ''})"
+                    )
+            else:
+                console.print("[red]Failed to create profile[/red]")
+                sys.exit(ExitCode.GENERIC_ERROR)
+
+        await run_with_client(create_profile)
+
+    asyncio.run(run_cmd())
+
+
+@profile_group.command(name="rename")
+@click.argument("profile_identifier")
+@click.argument("new_name")
+@force_option
+@network_option
+@click.pass_context
+def profile_rename(
+    ctx: click.Context,
+    profile_identifier: str,
+    new_name: str,
+    force: Optional[bool],
+    network_id: Optional[str],
+) -> None:
+    """Rename a profile.
+
+    \b
+    Arguments:
+      PROFILE_IDENTIFIER  Profile ID or name
+      NEW_NAME            New name for the profile
+    """
+    cli_ctx = apply_options(ctx, network_id=network_id, force=force)
+    console = cli_ctx.console
+
+    async def run_cmd() -> None:
+        async def rename_profile(client: EeroClient) -> None:
+            with cli_ctx.status("Finding profile..."):
+                raw_response = await client.get_profiles(cli_ctx.network_id)
+
+            profiles = extract_profiles(raw_response)
+            target = _find_profile(profiles, profile_identifier)
+
+            if not target or not target.get("id"):
+                console.print(f"[red]Profile '{profile_identifier}' not found[/red]")
+                console.print("[dim]Try: eero profile list[/dim]")
+                sys.exit(ExitCode.NOT_FOUND)
+
+            try:
+                confirm_or_fail(
+                    action="rename",
+                    target=f"{target.get('name') or profile_identifier} → {new_name}",
+                    risk=OperationRisk.MEDIUM,
+                    force=cli_ctx.force,
+                    non_interactive=cli_ctx.non_interactive,
+                    dry_run=cli_ctx.dry_run,
+                    console=cli_ctx.console,
+                )
+            except SafetyError as e:
+                cli_ctx.renderer.render_error(e.message)
+                sys.exit(e.exit_code)
+
+            with cli_ctx.status("Renaming profile..."):
+                result = await client.rename_profile(target["id"], new_name, cli_ctx.network_id)
+
+            meta = result.get("meta", {}) if isinstance(result, dict) else {}
+            if meta.get("code") == 200 or result:
+                console.print(f"[bold green]Profile renamed to '{new_name}'[/bold green]")
+            else:
+                console.print("[red]Failed to rename profile[/red]")
+                sys.exit(ExitCode.GENERIC_ERROR)
+
+        await run_with_client(rename_profile)
+
+    asyncio.run(run_cmd())
+
+
+@profile_group.command(name="delete")
+@click.argument("profile_identifier")
+@force_option
+@network_option
+@click.pass_context
+def profile_delete(
+    ctx: click.Context,
+    profile_identifier: str,
+    force: Optional[bool],
+    network_id: Optional[str],
+) -> None:
+    """Delete a profile.
+
+    \b
+    Arguments:
+      PROFILE_IDENTIFIER  Profile ID or name
+    """
+    cli_ctx = apply_options(ctx, network_id=network_id, force=force)
+    console = cli_ctx.console
+
+    async def run_cmd() -> None:
+        async def delete_profile(client: EeroClient) -> None:
+            with cli_ctx.status("Finding profile..."):
+                raw_response = await client.get_profiles(cli_ctx.network_id)
+
+            profiles = extract_profiles(raw_response)
+            target = _find_profile(profiles, profile_identifier)
+
+            if not target or not target.get("id"):
+                console.print(f"[red]Profile '{profile_identifier}' not found[/red]")
+                console.print("[dim]Try: eero profile list[/dim]")
+                sys.exit(ExitCode.NOT_FOUND)
+
+            try:
+                confirm_or_fail(
+                    action="delete",
+                    target=target.get("name") or profile_identifier,
+                    risk=OperationRisk.HIGH,
+                    confirmation_phrase="DELETE",
+                    force=cli_ctx.force,
+                    non_interactive=cli_ctx.non_interactive,
+                    dry_run=cli_ctx.dry_run,
+                    console=cli_ctx.console,
+                )
+            except SafetyError as e:
+                cli_ctx.renderer.render_error(e.message)
+                sys.exit(e.exit_code)
+
+            with cli_ctx.status("Deleting profile..."):
+                result = await client.delete_profile(target["id"], cli_ctx.network_id)
+
+            meta = result.get("meta", {}) if isinstance(result, dict) else {}
+            if meta.get("code") == 200 or result:
+                console.print("[bold green]Profile deleted[/bold green]")
+            else:
+                console.print("[red]Failed to delete profile[/red]")
+                sys.exit(ExitCode.GENERIC_ERROR)
+
+        await run_with_client(delete_profile)
 
     asyncio.run(run_cmd())
 

--- a/tests/cli/commands/test_network_mutations.py
+++ b/tests/cli/commands/test_network_mutations.py
@@ -1,0 +1,303 @@
+"""Mutation regression tests for eeroctl network commands.
+
+Guards the contract between eeroctl mutation commands and the EeroClient methods
+affected by the eero-api 4.1.2 routing/payload fix.  Each test patches
+``run_with_client`` at the module where it is imported and asserts that the
+correct EeroClient method is called with the expected positional arguments.
+
+See PR42-PLAN.md §T1 for rationale.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from eeroctl.main import cli
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_OK_RESPONSE = {"meta": {"code": 200, "error": None}, "data": {}}
+_ERR_RESPONSE = {"meta": {"code": 500, "error": "boom"}, "data": {}}
+
+NID = "NID"
+
+
+def _make_run_with_client(mock_client: MagicMock):
+    """Return a coroutine that mimics run_with_client, injecting *mock_client*."""
+
+    async def _run(func):
+        await func(mock_client)
+
+    return _run
+
+
+def _make_mock_client(**method_return_values) -> MagicMock:
+    """Build a MagicMock EeroClient whose named async methods return preset values."""
+    client = MagicMock()
+    for method_name, return_value in method_return_values.items():
+        setattr(client, method_name, AsyncMock(return_value=return_value))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# TestNetworkRename
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkRename:
+    """Tests for ``eero network rename`` → ``client.set_network_name``."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Mock EeroClient with set_network_name returning a 200 response."""
+        return _make_mock_client(set_network_name=_OK_RESPONSE)
+
+    def test_network_rename_calls_set_network_name(self, runner: CliRunner, mock_client: MagicMock):
+        """rename passes (name, network_id) to set_network_name and exits 0."""
+        with patch(
+            "eeroctl.commands.network.base.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli, ["network", "rename", "--name", "my-ssid", "--force", "--network-id", NID]
+            )
+
+        mock_client.set_network_name.assert_called_once_with("my-ssid", NID)
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestSQM
+# ---------------------------------------------------------------------------
+
+
+class TestSQM:
+    """Tests for ``eero network sqm enable/disable`` → ``client.set_sqm_enabled``."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_client_true(self) -> MagicMock:
+        """Mock client returning truthy response for set_sqm_enabled."""
+        return _make_mock_client(set_sqm_enabled=_OK_RESPONSE)
+
+    @pytest.fixture
+    def mock_client_false(self) -> MagicMock:
+        """Mock client returning truthy response for set_sqm_enabled (disable path)."""
+        return _make_mock_client(set_sqm_enabled=_OK_RESPONSE)
+
+    def test_sqm_enable_calls_set_sqm_enabled_with_boolean(
+        self, runner: CliRunner, mock_client_true: MagicMock
+    ):
+        """sqm enable passes bare True boolean to set_sqm_enabled (locks eero-api 4.1.2 contract)."""
+        with patch(
+            "eeroctl.commands.network.sqm.run_with_client",
+            side_effect=_make_run_with_client(mock_client_true),
+        ):
+            result = runner.invoke(
+                cli, ["--network-id", NID, "network", "sqm", "enable", "--force"]
+            )
+
+        mock_client_true.set_sqm_enabled.assert_called_once_with(True, NID)
+        assert result.exit_code == 0
+
+    def test_sqm_disable_passes_false(self, runner: CliRunner, mock_client_false: MagicMock):
+        """sqm disable passes bare False boolean to set_sqm_enabled."""
+        with patch(
+            "eeroctl.commands.network.sqm.run_with_client",
+            side_effect=_make_run_with_client(mock_client_false),
+        ):
+            result = runner.invoke(
+                cli, ["--network-id", NID, "network", "sqm", "disable", "--force"]
+            )
+
+        mock_client_false.set_sqm_enabled.assert_called_once_with(False, NID)
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestDNS
+# ---------------------------------------------------------------------------
+
+
+class TestDNS:
+    """Tests for DNS mutation commands."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Mock EeroClient with DNS methods returning OK responses."""
+        return _make_mock_client(set_dns_caching=_OK_RESPONSE, set_dns_mode=_OK_RESPONSE)
+
+    def test_dns_caching_enable_calls_set_dns_caching(
+        self, runner: CliRunner, mock_client: MagicMock
+    ):
+        """dns caching enable passes (True, network_id) to set_dns_caching."""
+        with patch(
+            "eeroctl.commands.network.dns.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--network-id", NID, "network", "dns", "caching", "enable", "--force"],
+            )
+
+        mock_client.set_dns_caching.assert_called_once_with(True, NID)
+        assert result.exit_code == 0
+
+    def test_dns_mode_set_calls_set_dns_mode(self, runner: CliRunner, mock_client: MagicMock):
+        """dns mode set google passes (mode, servers, network_id) to set_dns_mode."""
+        with patch(
+            "eeroctl.commands.network.dns.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--network-id", NID, "network", "dns", "mode", "set", "google", "--force"],
+            )
+
+        # servers=None because no --servers flag was provided for a non-custom mode
+        mock_client.set_dns_mode.assert_called_once_with("google", None, NID)
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestGuestNetwork
+# ---------------------------------------------------------------------------
+
+
+class TestGuestNetwork:
+    """Tests for ``eero network guest enable`` → ``client.set_guest_network``."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Mock EeroClient with set_guest_network returning a 200 response."""
+        return _make_mock_client(set_guest_network=_OK_RESPONSE)
+
+    def test_guest_network_enable_calls_set_guest_network(
+        self, runner: CliRunner, mock_client: MagicMock
+    ):
+        """guest enable invokes set_guest_network on the client."""
+        with patch(
+            "eeroctl.commands.network.guest.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli, ["--network-id", NID, "network", "guest", "enable", "--force"]
+            )
+
+        mock_client.set_guest_network.assert_called_once()
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# TestSecurityToggles
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityToggles:
+    """Tests for security toggle commands dispatched via _make_security_toggle factory."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    def _invoke_security(
+        self, runner: CliRunner, subcommand: str, method_name: str, expected_value: bool
+    ):
+        """Shared helper: patch run_with_client, invoke security subcommand, assert call."""
+        mock_client = _make_mock_client(**{method_name: _OK_RESPONSE})
+        with patch(
+            "eeroctl.commands.network.security.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["--network-id", NID, "network", "security", subcommand, "enable", "--force"],
+            )
+        getattr(mock_client, method_name).assert_called_once_with(expected_value, NID)
+        assert result.exit_code == 0
+        return result
+
+    def test_security_toggle_wpa3_enable_calls_set_wpa3(self, runner: CliRunner):
+        """wpa3 enable passes (True, network_id) to set_wpa3."""
+        self._invoke_security(runner, "wpa3", "set_wpa3", True)
+
+    def test_security_toggle_band_steering_enable_calls_set_band_steering(self, runner: CliRunner):
+        """band-steering enable passes (True, network_id) to set_band_steering."""
+        self._invoke_security(runner, "band-steering", "set_band_steering", True)
+
+    def test_security_toggle_upnp_enable_calls_set_upnp(self, runner: CliRunner):
+        """upnp enable passes (True, network_id) to set_upnp."""
+        self._invoke_security(runner, "upnp", "set_upnp", True)
+
+    def test_security_toggle_ipv6_enable_calls_set_ipv6(self, runner: CliRunner):
+        """ipv6 enable passes (True, network_id) to set_ipv6."""
+        self._invoke_security(runner, "ipv6", "set_ipv6", True)
+
+    def test_security_toggle_thread_enable_calls_set_thread_enabled(self, runner: CliRunner):
+        """thread enable maps CLI subcommand 'thread' to client method set_thread_enabled."""
+        self._invoke_security(runner, "thread", "set_thread_enabled", True)
+
+
+# ---------------------------------------------------------------------------
+# TestMutationSuccessAndFailure
+# ---------------------------------------------------------------------------
+
+
+class TestMutationSuccessAndFailure:
+    """Integration-level success/failure path tests using set_network_name as representative."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    def test_mutation_success_meta_200_returns_exit_zero(self, runner: CliRunner):
+        """When the mock returns meta.code 200, rename exits 0."""
+        mock_client = _make_mock_client(set_network_name=_OK_RESPONSE)
+        with patch(
+            "eeroctl.commands.network.base.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["network", "rename", "--name", "new-name", "--force", "--network-id", NID],
+            )
+
+        assert result.exit_code == 0
+
+    def test_mutation_failure_meta_non_200_returns_nonzero(self, runner: CliRunner):
+        """When the mock returns meta.code 500, rename exits non-zero."""
+        mock_client = _make_mock_client(set_network_name=_ERR_RESPONSE)
+        with patch(
+            "eeroctl.commands.network.base.run_with_client",
+            side_effect=_make_run_with_client(mock_client),
+        ):
+            result = runner.invoke(
+                cli,
+                ["network", "rename", "--name", "new-name", "--force", "--network-id", NID],
+            )
+
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Consumes the new profile management surface added in `eero-api` **4.1.0** (`create_profile`, `rename_profile`, `delete_profile`) and locks the call shape between eeroctl and the `EeroClient` methods affected by the **4.1.2** server-side routing fix to `/networks/{id}/settings`.

### Feature commits

- **`feat(profile)`** — three new subcommands on `eero profile`:
  - `eero profile create NAME` — non-destructive; no confirmation gate.
  - `eero profile rename PROFILE NEW_NAME` — `OperationRisk.MEDIUM` (mirrors `pause`/`unpause`).
  - `eero profile delete PROFILE [--force]` — `OperationRisk.HIGH` with `confirmation_phrase=\"DELETE\"`; `--force` bypasses the typed phrase via the existing short-circuit in `safety.py`.
  - Help-text inventory in `profile_group` docstring + Examples block updated.

- **`test(network)`** — new `tests/cli/commands/test_network_mutations.py` with 13 regression tests covering:
  - `set_network_name` (the `network rename` call path the 4.1.2 fix targeted).
  - `set_sqm_enabled` — locks the bare-boolean payload contract that 4.1.2 also corrected.
  - `set_dns_caching`, `set_dns_mode`, `set_guest_network`.
  - All five `_make_security_toggle` outputs (`wpa3`, `band-steering`, `upnp`, `ipv6`, `thread` → `set_thread_enabled`).
  - Representative success-on-`meta.code==200` and failure-on-non-200 paths.

### Quality gates (local)

- `uv run ruff check src/ tests/` — clean
- `uv run black --check src/ tests/` — clean
- `uv run isort --check-only src/ tests/` — clean
- `uv run mypy src/` — clean (46 files)
- `uv run pytest tests/` — **407 passed, 1 skipped** (pre-existing skip; pre-existing `test_auth.py` warning is unrelated)
- No changes to `pyproject.toml` or `uv.lock`.

## Test plan

- [x] All existing tests still pass on Py 3.13 locally.
- [x] New mutation regression tests pass via `uv run pytest tests/cli/commands/test_network_mutations.py -v`.
- [x] `eero profile --help` lists `create`, `rename`, `delete` alongside the existing subcommands.
- [ ] CI confirms green on Py 3.12 / 3.13 / 3.14.

## Follow-ups (deferred, not blocking)

- Add a `TestProfileMutations` class in `tests/cli/commands/test_profile.py` mirroring `TestNetworkRename` — patch `eeroctl.commands.profile.run_with_client` and assert call shape against `create_profile` / `rename_profile` / `delete_profile`, including the `--force` bypass on `delete`. The new commands are exercised today only via help-text fixtures and the mocked-client surface in the network suite.
- Informational security note: user-supplied profile names are interpolated into `rich.Console.print` calls and may render embedded Rich markup. This matches the pre-existing pattern across `profile_show` / `_set_profile_paused` and is acceptable for a local CLI; markup-disable hardening can be tracked separately.