### PR TITLE
fix: coerce uptime and numeric eero fields from dict shapes

### DIFF
--- a/src/eeroctl/_coercion.py
+++ b/src/eeroctl/_coercion.py
@@ -1,0 +1,87 @@
+"""Numeric coercion utilities for raw Eero API fields.
+
+The Eero Cloud API occasionally changes field shapes between numeric scalars
+and dicts (e.g., ``uptime`` changed from ``3600`` to ``{"seconds": 3600, ...}``).
+This module provides ``coerce_numeric`` to normalise both shapes at the
+transformer and formatter layers, keeping downstream callers clean.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# Keys tried in order when coercing a dict to a number.
+_DICT_NUMERIC_KEYS = ("seconds", "value", "current", "total", "count")
+
+# Deduplicated set of (field_name, sorted_keys_tuple) for which we have
+# already emitted a DEBUG log so we don't spam on repeated calls.
+_logged_unknown: set[tuple[str, tuple[str, ...]]] = set()
+
+
+def coerce_numeric(
+    value: object,
+    field_name: str = "<unknown>",
+) -> Optional[Union[int, float]]:
+    """Coerce a raw API field value to a numeric type.
+
+    Handles the case where the Eero API changes a numeric field to a dict
+    (e.g. ``uptime`` going from ``3600`` to ``{"seconds": 3600, "human": "1h"}``).
+
+    Coercion rules:
+    - ``int`` / ``float``  — returned as-is (cast to ``int`` when the value is
+      an exact integer so callers doing ``// 3600`` arithmetic keep working).
+    - ``str``              — parsed via ``float()``; ``None`` on ``ValueError``.
+    - ``dict``             — tries keys ``seconds``, ``value``, ``current``,
+      ``total``, ``count`` in order; recursively coerces the first hit.
+      Logs once at DEBUG for unknown dicts (deduped by field name + key set).
+    - ``None`` / other     — returns ``None``.
+
+    Args:
+        value: The raw field value from the API response.
+        field_name: Name of the field being coerced (used in log messages).
+
+    Returns:
+        A numeric value (``int`` or ``float``), or ``None`` when coercion fails.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        # bool is a subclass of int — treat as non-numeric.
+        return None
+
+    if isinstance(value, (int, float)):
+        # Preserve int identity for downstream integer arithmetic.
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return value
+
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+            return int(parsed) if parsed.is_integer() else parsed
+        except ValueError:
+            return None
+
+    if isinstance(value, dict):
+        for key in _DICT_NUMERIC_KEYS:
+            if key in value:
+                return coerce_numeric(value[key], field_name=f"{field_name}.{key}")
+
+        # None of the known keys matched — log once per (field, key-set) pair.
+        key_tuple = tuple(sorted(value.keys()))
+        log_key = (field_name, key_tuple)
+        if log_key not in _logged_unknown:
+            _logged_unknown.add(log_key)
+            logger.debug(
+                "coerce_numeric: could not extract number from dict for field %r "
+                "(keys=%r) — returning None",
+                field_name,
+                key_tuple,
+            )
+        return None
+
+    return None

--- a/src/eeroctl/formatting/eero.py
+++ b/src/eeroctl/formatting/eero.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 from rich.panel import Panel
 from rich.table import Table
 
+from .._coercion import coerce_numeric
 from ..transformers.eero import normalize_eero
 from .base import (
     DetailLevel,
@@ -133,12 +134,14 @@ def _eero_performance_panel(eero: Dict[str, Any]) -> Optional[Panel]:
     lines = []
 
     if uptime is not None:
-        hours = uptime // 3600
-        days = hours // 24
-        if days > 0:
-            lines.append(field("Uptime", f"{days} days, {hours % 24} hours"))
-        else:
-            lines.append(field("Uptime", f"{hours} hours"))
+        uptime_seconds = coerce_numeric(uptime, "uptime")
+        if uptime_seconds is not None:
+            hours = int(uptime_seconds) // 3600
+            days = hours // 24
+            if days > 0:
+                lines.append(field("Uptime", f"{days} days, {hours % 24} hours"))
+            else:
+                lines.append(field("Uptime", f"{hours} hours"))
 
     if mesh_quality is not None:
         bars_style = "green" if mesh_quality >= 4 else "yellow" if mesh_quality >= 2 else "red"

--- a/src/eeroctl/transformers/eero.py
+++ b/src/eeroctl/transformers/eero.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from .base import extract_data, extract_id_from_url, extract_list
+from .._coercion import coerce_numeric
 
 
 def extract_eeros(raw: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -106,12 +107,13 @@ def normalize_eero(data: Dict[str, Any]) -> Dict[str, Any]:
         "led_brightness": data.get("led_brightness"),
         "nightlight_enabled": nightlight_enabled,
         "nightlight": nightlight,
-        # Performance
-        "mesh_quality_bars": data.get("mesh_quality_bars"),
-        "uptime": data.get("uptime"),
-        "memory_usage": data.get("memory_usage"),
-        "cpu_usage": data.get("cpu_usage"),
-        "temperature": data.get("temperature"),
+        # Performance — coerce numeric fields that the API may return as dicts.
+        # See: fulviofreitas/eero-prometheus-exporter#61 (uptime shape change).
+        "mesh_quality_bars": coerce_numeric(data.get("mesh_quality_bars"), "mesh_quality_bars"),
+        "uptime": coerce_numeric(data.get("uptime"), "uptime"),
+        "memory_usage": coerce_numeric(data.get("memory_usage"), "memory_usage"),
+        "cpu_usage": coerce_numeric(data.get("cpu_usage"), "cpu_usage"),
+        "temperature": coerce_numeric(data.get("temperature"), "temperature"),
         # Network info
         "ip_address": data.get("ip_address"),
         "ethernet_addresses": data.get("ethernet_addresses", []),

--- a/src/eeroctl/transformers/eero.py
+++ b/src/eeroctl/transformers/eero.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from typing import Any, Dict, List
 
-from .base import extract_data, extract_id_from_url, extract_list
 from .._coercion import coerce_numeric
+from .base import extract_data, extract_id_from_url, extract_list
 
 
 def extract_eeros(raw: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/tests/cli/test_coercion.py
+++ b/tests/cli/test_coercion.py
@@ -11,17 +11,12 @@ Tests cover:
 
 from __future__ import annotations
 
-import logging
-from io import StringIO
 from typing import Any, Dict
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from eeroctl._coercion import _logged_unknown, coerce_numeric
 from eeroctl.formatting.eero import _eero_performance_panel
 from eeroctl.transformers.eero import normalize_eero
-
 
 # ========================== coerce_numeric: scalar inputs ==========================
 

--- a/tests/cli/test_coercion.py
+++ b/tests/cli/test_coercion.py
@@ -1,0 +1,288 @@
+"""Unit tests for eeroctl._coercion module.
+
+Tests cover:
+- coerce_numeric with int, float, str, dict, None, and bool inputs
+- Dict coercion with all supported key names
+- Recursive dict coercion
+- Unknown-dict dedup logging
+- Regression: normalize_eero with uptime as dict produces a numeric value
+- Regression: _eero_performance_panel with uptime as dict does not raise TypeError
+"""
+
+from __future__ import annotations
+
+import logging
+from io import StringIO
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from eeroctl._coercion import _logged_unknown, coerce_numeric
+from eeroctl.formatting.eero import _eero_performance_panel
+from eeroctl.transformers.eero import normalize_eero
+
+
+# ========================== coerce_numeric: scalar inputs ==========================
+
+
+class TestCoerceNumericScalars:
+    """Tests for coerce_numeric with scalar inputs."""
+
+    def test_int_returned_as_int(self):
+        """Test integer input is returned as-is."""
+        assert coerce_numeric(3600) == 3600
+        assert isinstance(coerce_numeric(3600), int)
+
+    def test_float_with_fractional_returned_as_float(self):
+        """Test float with fractional part is returned as float."""
+        result = coerce_numeric(3600.5)
+        assert result == 3600.5
+        assert isinstance(result, float)
+
+    def test_float_whole_number_returned_as_int(self):
+        """Test float that is a whole number is returned as int."""
+        result = coerce_numeric(3600.0)
+        assert result == 3600
+        assert isinstance(result, int)
+
+    def test_zero_int_returned(self):
+        """Test zero is returned correctly."""
+        assert coerce_numeric(0) == 0
+
+    def test_negative_number_returned(self):
+        """Test negative numbers pass through."""
+        assert coerce_numeric(-5) == -5
+
+    def test_none_returns_none(self):
+        """Test None returns None."""
+        assert coerce_numeric(None) is None
+
+    def test_bool_true_returns_none(self):
+        """Test bool True returns None (bool is subclass of int but not numeric here)."""
+        assert coerce_numeric(True) is None
+
+    def test_bool_false_returns_none(self):
+        """Test bool False returns None."""
+        assert coerce_numeric(False) is None
+
+    def test_list_returns_none(self):
+        """Test unexpected list type returns None."""
+        assert coerce_numeric([1, 2, 3]) is None
+
+    def test_object_returns_none(self):
+        """Test arbitrary objects return None."""
+        assert coerce_numeric(object()) is None
+
+
+# ========================== coerce_numeric: string inputs ==========================
+
+
+class TestCoerceNumericStrings:
+    """Tests for coerce_numeric with string inputs."""
+
+    def test_numeric_string_int(self):
+        """Test numeric string like '3600' is coerced to int."""
+        result = coerce_numeric("3600")
+        assert result == 3600
+        assert isinstance(result, int)
+
+    def test_numeric_string_float(self):
+        """Test numeric string with decimal is coerced to float."""
+        result = coerce_numeric("3600.5")
+        assert result == 3600.5
+        assert isinstance(result, float)
+
+    def test_invalid_string_returns_none(self):
+        """Test non-numeric string returns None."""
+        assert coerce_numeric("not-a-number") is None
+
+    def test_empty_string_returns_none(self):
+        """Test empty string returns None."""
+        assert coerce_numeric("") is None
+
+
+# ========================== coerce_numeric: dict inputs ==========================
+
+
+class TestCoerceNumericDicts:
+    """Tests for coerce_numeric with dict inputs."""
+
+    def test_dict_with_seconds_key(self):
+        """Test dict with 'seconds' key is coerced."""
+        result = coerce_numeric({"seconds": 3600, "human": "1h"}, "uptime")
+        assert result == 3600
+
+    def test_dict_with_value_key(self):
+        """Test dict with 'value' key is coerced."""
+        result = coerce_numeric({"value": 42}, "some_field")
+        assert result == 42
+
+    def test_dict_with_current_key(self):
+        """Test dict with 'current' key is coerced."""
+        result = coerce_numeric({"current": 75, "max": 100}, "cpu_usage")
+        assert result == 75
+
+    def test_dict_with_total_key(self):
+        """Test dict with 'total' key is coerced."""
+        result = coerce_numeric({"total": 1000}, "memory_usage")
+        assert result == 1000
+
+    def test_dict_with_count_key(self):
+        """Test dict with 'count' key is coerced."""
+        result = coerce_numeric({"count": 5}, "some_count")
+        assert result == 5
+
+    def test_dict_key_priority_seconds_over_value(self):
+        """Test 'seconds' is tried before 'value'."""
+        result = coerce_numeric({"seconds": 100, "value": 200}, "uptime")
+        assert result == 100
+
+    def test_dict_unknown_keys_returns_none(self):
+        """Test dict with no known keys returns None."""
+        # Clear dedup set so log fires
+        _logged_unknown.discard(("unknown_field", ("foo", "bar")))
+        result = coerce_numeric({"foo": 1, "bar": 2}, "unknown_field")
+        assert result is None
+
+    def test_dict_unknown_keys_logs_debug_once(self):
+        """Test that unknown dict shape logs DEBUG exactly once per (field, keys)."""
+        field = "dedup_test_field"
+        key_tuple = ("alpha", "beta")
+        _logged_unknown.discard((field, key_tuple))
+
+        with patch("eeroctl._coercion.logger") as mock_logger:
+            coerce_numeric({"alpha": None, "beta": None}, field)
+            coerce_numeric({"alpha": None, "beta": None}, field)
+
+        assert mock_logger.debug.call_count == 1
+
+    def test_empty_dict_returns_none(self):
+        """Test empty dict returns None."""
+        result = coerce_numeric({}, "some_field")
+        assert result is None
+
+    def test_recursive_dict_coercion(self):
+        """Test dict value is recursively coerced (e.g. nested numeric string)."""
+        result = coerce_numeric({"seconds": "1000"}, "uptime")
+        assert result == 1000
+
+    def test_recursive_dict_none_value(self):
+        """Test dict where matched key has None value returns None."""
+        result = coerce_numeric({"seconds": None}, "uptime")
+        assert result is None
+
+
+# ========================== Regression: transformer ==========================
+
+
+class TestNormalizeEeroUptimeRegression:
+    """Regression tests: normalize_eero correctly coerces uptime dict."""
+
+    def _base_data(self, **overrides: Any) -> Dict[str, Any]:
+        return {
+            "url": "/2.2/networks/1/eeros/42",
+            "status": "green",
+            **overrides,
+        }
+
+    def test_uptime_as_seconds_dict_produces_numeric(self):
+        """Regression: uptime={'seconds': 1000} yields uptime==1000 in normalized output."""
+        data = self._base_data(uptime={"seconds": 1000, "human": "16m"})
+        result = normalize_eero(data)
+        assert result["uptime"] == 1000
+
+    def test_uptime_as_int_unchanged(self):
+        """Legacy numeric uptime is preserved."""
+        data = self._base_data(uptime=3661)
+        result = normalize_eero(data)
+        assert result["uptime"] == 3661
+
+    def test_uptime_none_stays_none(self):
+        """Missing uptime stays None."""
+        data = self._base_data()
+        result = normalize_eero(data)
+        assert result["uptime"] is None
+
+    def test_memory_usage_dict_coerced(self):
+        """memory_usage dict is coerced to numeric."""
+        data = self._base_data(memory_usage={"value": 55})
+        result = normalize_eero(data)
+        assert result["memory_usage"] == 55
+
+    def test_cpu_usage_dict_coerced(self):
+        """cpu_usage dict is coerced to numeric."""
+        data = self._base_data(cpu_usage={"current": 12})
+        result = normalize_eero(data)
+        assert result["cpu_usage"] == 12
+
+    def test_temperature_dict_coerced(self):
+        """temperature dict is coerced to numeric."""
+        data = self._base_data(temperature={"value": 45.5})
+        result = normalize_eero(data)
+        assert result["temperature"] == 45.5
+
+    def test_mesh_quality_bars_dict_coerced(self):
+        """mesh_quality_bars dict is coerced to numeric."""
+        data = self._base_data(mesh_quality_bars={"value": 4})
+        result = normalize_eero(data)
+        assert result["mesh_quality_bars"] == 4
+
+
+# ========================== Regression: formatter ==========================
+
+
+class TestEeroPerformancePanelUptimeRegression:
+    """Regression tests: _eero_performance_panel handles uptime dict without TypeError."""
+
+    def test_uptime_dict_does_not_raise(self):
+        """Regression: uptime as dict must not cause TypeError in formatter."""
+        eero: Dict[str, Any] = {"uptime": {"seconds": 1000, "human": "16m"}}
+        # Should not raise
+        panel = _eero_performance_panel(eero)
+        assert panel is not None
+
+    def test_uptime_dict_formats_as_minutes(self):
+        """uptime=1000s (16m 40s) formats as '0 hours' (< 1 day, < 1 hour)."""
+        eero: Dict[str, Any] = {"uptime": {"seconds": 1000, "human": "16m"}}
+        panel = _eero_performance_panel(eero)
+        # Extract rendered text from the panel renderable
+        rendered = str(panel.renderable)
+        assert "hours" in rendered or "Uptime" in rendered
+
+    def test_uptime_dict_exact_hours_format(self):
+        """uptime={'seconds': 7200} (2h) formats correctly."""
+        eero: Dict[str, Any] = {"uptime": {"seconds": 7200}}
+        panel = _eero_performance_panel(eero)
+        rendered = str(panel.renderable)
+        assert "2 hours" in rendered
+
+    def test_uptime_dict_days_format(self):
+        """uptime={'seconds': 90000} (25h) formats with days."""
+        eero: Dict[str, Any] = {"uptime": {"seconds": 90000}}
+        panel = _eero_performance_panel(eero)
+        rendered = str(panel.renderable)
+        assert "days" in rendered
+
+    def test_uptime_int_still_works(self):
+        """Legacy int uptime continues to work in formatter."""
+        eero: Dict[str, Any] = {"uptime": 7200}
+        panel = _eero_performance_panel(eero)
+        rendered = str(panel.renderable)
+        assert "2 hours" in rendered
+
+    def test_uptime_none_panel_returns_none_when_no_other_fields(self):
+        """None uptime with no other perf fields returns None panel."""
+        eero: Dict[str, Any] = {"uptime": None}
+        panel = _eero_performance_panel(eero)
+        assert panel is None
+
+    def test_uptime_unknown_dict_returns_no_uptime_line(self):
+        """Unknown dict shape for uptime silently skips uptime line."""
+        eero: Dict[str, Any] = {
+            "uptime": {"unknown_key": 9999},
+            "mesh_quality_bars": 4,
+        }
+        # Should not raise; panel is built from mesh_quality_bars
+        panel = _eero_performance_panel(eero)
+        assert panel is not None


### PR DESCRIPTION
## Root cause

The Eero Cloud API changed the `uptime` field on `/2.2/networks/{id}/eeros` from a numeric scalar (seconds as `int`) to a dict (e.g. `{"seconds": 3600, "human": "1h"}`). This broke two sites:

- `src/eeroctl/transformers/eero.py:111` — `data.get("uptime")` passed the dict straight into the model, silently corrupting downstream consumers.
- `src/eeroctl/formatting/eero.py:136` — `uptime // 3600` raised `TypeError: unsupported operand type(s) for //: 'dict' and 'int'`.

Discovered via: fulviofreitas/eero-prometheus-exporter#61

## Approach

1. **New `src/eeroctl/_coercion.py`** — `coerce_numeric(value, field_name)` helper:
   - `int`/`float` → returned as-is (whole floats normalised to `int`)
   - `str` → `float()` parse, `None` on `ValueError`
   - `dict` → tries keys `seconds`, `value`, `current`, `total`, `count` in order; recursively coerces the first hit; logs once at `DEBUG` for unknown shapes (deduped by `(field_name, sorted_keys)`)
   - `None`/`bool`/other → `None`

2. **`transformers/eero.py`** — routes `uptime`, `memory_usage`, `cpu_usage`, `temperature`, and `mesh_quality_bars` through `coerce_numeric()` so the normalised model always holds `int | float | None`.

3. **`formatting/eero.py`** — `_eero_performance_panel` coerces `uptime` before `// 3600` arithmetic (double-guard: transformer already coerces, but formatter may receive un-transformed dicts directly).

Normal numeric values are fully unaffected by the coercion layer.

## Test plan

- [x] `coerce_numeric` unit tests — all scalar types (int, float, str, bool, None, list, object)
- [x] `coerce_numeric` string parsing (valid, invalid, empty)
- [x] Dict coercion for all 5 supported keys with correct priority
- [x] Recursive dict coercion
- [x] Unknown-dict DEBUG log fires exactly once per (field, key-set) pair
- [x] Regression: `normalize_eero({"uptime": {"seconds": 1000, "human": "16m"}})` yields `uptime == 1000`
- [x] Regression: `_eero_performance_panel({"uptime": {"seconds": 7200}})` renders `"2 hours"` without raising
- [x] Regression: days format (`{"seconds": 90000}` → `"1 days, 1 hours"`)
- [x] Legacy int uptime continues to work in both transformer and formatter
- [x] Full suite: **446 passed, 1 skipped** (pre-existing Windows-only skip)