### PR TITLE
fix(cli): repair device/activity commands and add device pause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "eero-api==5.0.0",
+    "eero-api==6.0.0",
     "rich>=13.0.0",
     "click>=8.0.0",
     "pyyaml>=6.0.0",

--- a/src/eeroctl/commands/activity.py
+++ b/src/eeroctl/commands/activity.py
@@ -1,10 +1,8 @@
 """Activity commands for the Eero CLI (Eero Plus feature).
 
 Commands:
-- eero activity summary: Network activity summary
-- eero activity clients: Per-client activity
-- eero activity history: Historical activity
-- eero activity categories: Activity by category
+- eero activity history: Historical activity data (get_insights)
+- eero activity categories: Activity by category (get_insights, blocked)
 """
 
 import sys
@@ -12,27 +10,13 @@ from typing import Optional
 
 import click
 from eero import EeroClient
-from rich.panel import Panel
 from rich.table import Table
 
 from ..context import ensure_cli_context
 from ..errors import is_premium_error
 from ..exit_codes import ExitCode
 from ..options import apply_options, network_option, output_option
-from ..transformers import extract_data
 from ..utils import with_client
-
-
-def _format_bytes(bytes_val: int) -> str:
-    """Format bytes into human-readable format."""
-    if bytes_val < 1024:
-        return f"{bytes_val} B"
-    elif bytes_val < 1024 * 1024:
-        return f"{bytes_val / 1024:.1f} KB"
-    elif bytes_val < 1024 * 1024 * 1024:
-        return f"{bytes_val / (1024 * 1024):.1f} MB"
-    else:
-        return f"{bytes_val / (1024 * 1024 * 1024):.2f} GB"
 
 
 @click.group(name="activity")
@@ -42,122 +26,36 @@ def activity_group(ctx: click.Context) -> None:
 
     \b
     Commands:
-      summary    - Network activity summary
-      clients    - Per-client activity
-      history    - Historical activity
-      categories - Activity by category
+      history    - Historical activity (requires --start and --end)
+      categories - Blocked-traffic activity by category (requires --start and --end)
 
     \b
     Note: Requires an active Eero Plus subscription.
 
     \b
     Examples:
-      eero activity summary
-      eero activity clients
-      eero activity history --period week
+      eero activity history --start 2026-07-01 --end 2026-07-22
+      eero activity categories --start 2026-07-01 --end 2026-07-22 --cadence weekly
     """
     ensure_cli_context(ctx)
 
 
-@activity_group.command(name="summary")
-@output_option
-@network_option
-@click.pass_context
-@with_client
-async def activity_summary(
-    ctx: click.Context, client: EeroClient, output: Optional[str], network_id: Optional[str]
-) -> None:
-    """Show network activity summary."""
-    cli_ctx = apply_options(ctx, output=output, network_id=network_id)
-    console = cli_ctx.console
-
-    with cli_ctx.status("Getting network activity..."):
-        try:
-            raw_response = await client.get_activity(cli_ctx.network_id)
-        except Exception as e:
-            if is_premium_error(e):
-                console.print("[yellow]This feature requires Eero Plus subscription[/yellow]")
-                sys.exit(ExitCode.PREMIUM_REQUIRED)
-            raise
-
-    activity_data = extract_data(raw_response) if isinstance(raw_response, dict) else raw_response
-
-    if cli_ctx.is_structured_output():
-        cli_ctx.render_structured(activity_data, "eero.activity.summary/v1")
-    else:
-        upload = activity_data.get("upload_bytes", 0) if isinstance(activity_data, dict) else 0
-        download = activity_data.get("download_bytes", 0) if isinstance(activity_data, dict) else 0
-        total = upload + download
-
-        content = (
-            f"[bold cyan]Download:[/bold cyan] {_format_bytes(download)}\n"
-            f"[bold cyan]Upload:[/bold cyan] {_format_bytes(upload)}\n"
-            f"[bold cyan]Total:[/bold cyan] {_format_bytes(total)}"
-        )
-        console.print(Panel(content, title="Network Activity Summary", border_style="blue"))
-
-
-@activity_group.command(name="clients")
-@output_option
-@network_option
-@click.pass_context
-@with_client
-async def activity_clients(
-    ctx: click.Context, client: EeroClient, output: Optional[str], network_id: Optional[str]
-) -> None:
-    """Show per-client activity data."""
-    cli_ctx = apply_options(ctx, output=output, network_id=network_id)
-    console = cli_ctx.console
-
-    with cli_ctx.status("Getting client activity..."):
-        try:
-            raw_response = await client.get_activity_clients(cli_ctx.network_id)
-        except Exception as e:
-            if is_premium_error(e):
-                console.print("[yellow]This feature requires Eero Plus subscription[/yellow]")
-                sys.exit(ExitCode.PREMIUM_REQUIRED)
-            raise
-
-    clients_data = extract_data(raw_response) if isinstance(raw_response, dict) else raw_response
-    if isinstance(clients_data, dict):
-        clients_data = clients_data.get("clients", [])
-
-    if cli_ctx.is_structured_output():
-        cli_ctx.render_structured(clients_data, "eero.activity.clients/v1")
-    else:
-        if not clients_data:
-            console.print("[yellow]No client activity data available[/yellow]")
-            return
-
-        table = Table(title="Client Activity")
-        table.add_column("Device", style="cyan")
-        table.add_column("Download", justify="right")
-        table.add_column("Upload", justify="right")
-        table.add_column("Total", justify="right")
-
-        for client_info in clients_data:
-            name = (
-                client_info.get("display_name")
-                or client_info.get("hostname")
-                or client_info.get("mac", "Unknown")
-            )
-            download = client_info.get("download_bytes", 0)
-            upload = client_info.get("upload_bytes", 0)
-            total = download + upload
-
-            table.add_row(
-                name, _format_bytes(download), _format_bytes(upload), _format_bytes(total)
-            )
-
-        console.print(table)
-
-
 @activity_group.command(name="history")
+@click.option("--start", required=True, help="Start of window (ISO 8601, e.g. 2026-07-01)")
+@click.option("--end", required=True, help="End of window (ISO 8601, e.g. 2026-07-22)")
 @click.option(
-    "--period",
-    type=click.Choice(["hour", "day", "week", "month"]),
-    default="day",
-    help="Time period (default: day)",
+    "--insight-type",
+    type=click.Choice(["adblock", "blocked", "inspected"]),
+    default="inspected",
+    show_default=True,
+    help="Insight type to retrieve.",
+)
+@click.option(
+    "--cadence",
+    type=click.Choice(["hourly", "daily", "weekly"]),
+    default="daily",
+    show_default=True,
+    help="Data cadence.",
 )
 @output_option
 @network_option
@@ -166,87 +64,138 @@ async def activity_clients(
 async def activity_history(
     ctx: click.Context,
     client: EeroClient,
-    period: str,
+    start: str,
+    end: str,
+    insight_type: str,
+    cadence: str,
     output: Optional[str],
     network_id: Optional[str],
 ) -> None:
     """Show historical activity data.
 
     \b
-    Options:
-      --period  Time period: hour, day, week, month
+    Required:
+      --start ISO  Start of the time window (e.g. 2026-07-01)
+      --end ISO    End of the time window (e.g. 2026-07-22)
+
+    \b
+    Optional:
+      --insight-type  adblock | blocked | inspected (default: inspected)
+      --cadence       hourly | daily | weekly (default: daily)
     """
     cli_ctx = apply_options(ctx, output=output, network_id=network_id)
     console = cli_ctx.console
 
-    with cli_ctx.status(f"Getting activity history ({period})..."):
+    with cli_ctx.status("Getting activity history..."):
         try:
-            raw_response = await client.get_activity_history(cli_ctx.network_id, period)
+            raw_response = await client.get_insights(
+                cli_ctx.network_id,
+                start=start,
+                end=end,
+                insight_type=insight_type,
+                cadence=cadence,
+            )
         except Exception as e:
             if is_premium_error(e):
                 console.print("[yellow]This feature requires Eero Plus subscription[/yellow]")
                 sys.exit(ExitCode.PREMIUM_REQUIRED)
             raise
 
-    history_data = extract_data(raw_response) if isinstance(raw_response, dict) else raw_response
-    if not isinstance(history_data, dict):
-        history_data = {}
-
     if cli_ctx.is_structured_output():
-        cli_ctx.render_structured(history_data, "eero.activity.history/v1")
-    else:
-        total_download = history_data.get("total_download_bytes", 0)
-        total_upload = history_data.get("total_upload_bytes", 0)
-        data_points = history_data.get("data_points", [])
+        cli_ctx.render_structured(raw_response, "eero.activity.history/v1")
+        return
 
-        content = (
-            f"[bold]Period:[/bold] {period}\n"
-            f"[bold cyan]Total Download:[/bold cyan] {_format_bytes(total_download)}\n"
-            f"[bold cyan]Total Upload:[/bold cyan] {_format_bytes(total_upload)}\n"
-            f"[bold]Data Points:[/bold] {len(data_points)}"
+    series = raw_response.get("data", {}).get("series", [])
+    if not series:
+        console.print("[yellow]No activity data available for the given window[/yellow]")
+        return
+
+    table = Table(title=f"Activity History ({insight_type}, {cadence})")
+    table.add_column("Insight Type", style="cyan")
+    table.add_column("Sum", justify="right", style="green")
+    table.add_column("Data Points", justify="right")
+
+    for entry in series:
+        table.add_row(
+            str(entry.get("insight_type", "")),
+            str(entry.get("sum", 0)),
+            str(len(entry.get("values", []))),
         )
-        console.print(Panel(content, title=f"Activity History ({period})", border_style="blue"))
+
+    console.print(table)
 
 
 @activity_group.command(name="categories")
+@click.option("--start", required=True, help="Start of window (ISO 8601, e.g. 2026-07-01)")
+@click.option("--end", required=True, help="End of window (ISO 8601, e.g. 2026-07-22)")
+@click.option(
+    "--cadence",
+    type=click.Choice(["hourly", "daily", "weekly"]),
+    default="daily",
+    show_default=True,
+    help="Data cadence.",
+)
 @output_option
 @network_option
 @click.pass_context
 @with_client
 async def activity_categories(
-    ctx: click.Context, client: EeroClient, output: Optional[str], network_id: Optional[str]
+    ctx: click.Context,
+    client: EeroClient,
+    start: str,
+    end: str,
+    cadence: str,
+    output: Optional[str],
+    network_id: Optional[str],
 ) -> None:
-    """Show activity grouped by category."""
+    """Show blocked-traffic activity by category.
+
+    \b
+    Required:
+      --start ISO  Start of the time window (e.g. 2026-07-01)
+      --end ISO    End of the time window (e.g. 2026-07-22)
+
+    \b
+    Optional:
+      --cadence  hourly | daily | weekly (default: daily)
+    """
     cli_ctx = apply_options(ctx, output=output, network_id=network_id)
     console = cli_ctx.console
 
     with cli_ctx.status("Getting activity categories..."):
         try:
-            raw_response = await client.get_activity_categories(cli_ctx.network_id)
+            raw_response = await client.get_insights(
+                cli_ctx.network_id,
+                start=start,
+                end=end,
+                insight_type="blocked",
+                cadence=cadence,
+            )
         except Exception as e:
             if is_premium_error(e):
                 console.print("[yellow]This feature requires Eero Plus subscription[/yellow]")
                 sys.exit(ExitCode.PREMIUM_REQUIRED)
             raise
 
-    categories_data = extract_data(raw_response) if isinstance(raw_response, dict) else raw_response
-    if isinstance(categories_data, dict):
-        categories_data = categories_data.get("categories", [])
-
     if cli_ctx.is_structured_output():
-        cli_ctx.render_structured(categories_data, "eero.activity.categories/v1")
-    else:
-        if not categories_data:
-            console.print("[yellow]No category data available[/yellow]")
-            return
+        cli_ctx.render_structured(raw_response, "eero.activity.categories/v1")
+        return
 
-        table = Table(title="Activity by Category")
-        table.add_column("Category", style="cyan")
-        table.add_column("Usage", justify="right")
+    series = raw_response.get("data", {}).get("series", [])
+    if not series:
+        console.print("[yellow]No category data available for the given window[/yellow]")
+        return
 
-        for category in categories_data:
-            name = category.get("name", "Unknown")
-            usage = category.get("bytes", 0)
-            table.add_row(name, _format_bytes(usage))
+    table = Table(title=f"Activity Categories (blocked, {cadence})")
+    table.add_column("Insight Type", style="cyan")
+    table.add_column("Sum", justify="right", style="green")
+    table.add_column("Data Points", justify="right")
 
-        console.print(table)
+    for entry in series:
+        table.add_row(
+            str(entry.get("insight_type", "")),
+            str(entry.get("sum", 0)),
+            str(len(entry.get("values", []))),
+        )
+
+    console.print(table)

--- a/src/eeroctl/commands/device.py
+++ b/src/eeroctl/commands/device.py
@@ -6,7 +6,8 @@ Commands:
 - eero device rename: Rename a device
 - eero device block: Block a device
 - eero device unblock: Unblock a device
-- eero device priority: Device priority management
+- eero device pause: Pause a device
+- eero device unpause: Unpause a device
 """
 
 import asyncio
@@ -15,7 +16,6 @@ from typing import Any, Dict, Literal, Optional
 
 import click
 from eero import EeroClient
-from rich.panel import Panel
 from rich.table import Table
 
 from ..context import EeroCliContext, ensure_cli_context
@@ -75,19 +75,20 @@ def device_group(ctx: click.Context) -> None:
 
     \b
     Commands:
-      list     - List all connected devices
-      show     - Show device details
-      rename   - Rename a device
-      block    - Block a device
-      unblock  - Unblock a device
-      priority - Bandwidth priority management
+      list    - List all connected devices
+      show    - Show device details
+      rename  - Rename a device
+      block   - Block a device
+      unblock - Unblock a device
+      pause   - Pause a device
+      unpause - Unpause a device
 
     \b
     Examples:
       eero device list                    # List all devices
       eero device show "iPhone"           # Show by name
       eero device block AA:BB:CC:DD:EE:FF # Block by MAC
-      eero device priority show "iPad"    # Show priority
+      eero device pause "iPad"            # Pause a device
     """
     ensure_cli_context(ctx)
 
@@ -368,38 +369,49 @@ def _set_device_blocked(cli_ctx: EeroCliContext, device_identifier: str, blocked
     asyncio.run(run_cmd())
 
 
-# ==================== Priority Subcommand Group ====================
-
-
-@device_group.group(name="priority")
-@click.pass_context
-def priority_group(ctx: click.Context) -> None:
-    """Manage device bandwidth priority.
-
-    \b
-    Commands:
-      show - Show priority status
-      on   - Enable priority
-      off  - Disable priority
-    """
-    pass
-
-
-@priority_group.command(name="show")
+@device_group.command(name="pause")
 @click.argument("device_identifier")
-@output_option
+@force_option
 @network_option
 @click.pass_context
-def priority_show(
-    ctx: click.Context, device_identifier: str, output: Optional[str], network_id: Optional[str]
+def device_pause(
+    ctx: click.Context, device_identifier: str, force: Optional[bool], network_id: Optional[str]
 ) -> None:
-    """Show priority status for a device."""
-    cli_ctx = apply_options(ctx, output=output, network_id=network_id)
+    """Pause a device's internet access.
+
+    \b
+    Arguments:
+      DEVICE_IDENTIFIER  Device ID, MAC address, or name
+    """
+    cli_ctx = apply_options(ctx, network_id=network_id, force=force)
+    _set_device_paused(cli_ctx, device_identifier, True)
+
+
+@device_group.command(name="unpause")
+@click.argument("device_identifier")
+@force_option
+@network_option
+@click.pass_context
+def device_unpause(
+    ctx: click.Context, device_identifier: str, force: Optional[bool], network_id: Optional[str]
+) -> None:
+    """Unpause a device's internet access.
+
+    \b
+    Arguments:
+      DEVICE_IDENTIFIER  Device ID, MAC address, or name
+    """
+    cli_ctx = apply_options(ctx, network_id=network_id, force=force)
+    _set_device_paused(cli_ctx, device_identifier, False)
+
+
+def _set_device_paused(cli_ctx: EeroCliContext, device_identifier: str, paused: bool) -> None:
+    """Pause or unpause a device."""
     console = cli_ctx.console
-    renderer = cli_ctx.renderer
+    action = "pause" if paused else "unpause"
 
     async def run_cmd() -> None:
-        async def get_priority(client: EeroClient) -> None:
+        async def toggle_pause(client: EeroClient) -> None:
             # Find device first
             with cli_ctx.status("Finding device..."):
                 raw_response = await client.get_devices(cli_ctx.network_id)
@@ -412,115 +424,37 @@ def priority_show(
                 console.print("[dim]Try: eero device list[/dim]")
                 sys.exit(ExitCode.NOT_FOUND)
 
-            with cli_ctx.status("Getting priority status..."):
-                raw_priority = await client.get_device_priority(target["id"], cli_ctx.network_id)
+            device_name = (
+                target.get("display_name")
+                or target.get("nickname")
+                or target.get("hostname")
+                or device_identifier
+            )
 
-            priority_data = extract_data(raw_priority)
-
-            if cli_ctx.is_json_output():
-                renderer.render_json(priority_data, "eero.device.priority.show/v1")
-            elif cli_ctx.is_list_output():
-                renderer.render_text(priority_data, "eero.device.priority.show/v1")
-            else:
-                prioritized = priority_data.get("prioritized", False)
-                duration = priority_data.get("duration", 0)
-
-                content = (
-                    f"[bold]Prioritized:[/bold] "
-                    f"{'[green]Yes[/green]' if prioritized else '[dim]No[/dim]'}"
+            try:
+                confirm_or_fail(
+                    action=action,
+                    target=device_name,
+                    risk=OperationRisk.MEDIUM,
+                    force=cli_ctx.force,
+                    non_interactive=cli_ctx.non_interactive,
+                    dry_run=cli_ctx.dry_run,
+                    console=cli_ctx.console,
                 )
-                if prioritized and duration > 0:
-                    content += f"\n[bold]Duration:[/bold] {duration} minutes"
+            except SafetyError as e:
+                cli_ctx.renderer.render_error(e.message)
+                sys.exit(e.exit_code)
 
-                console.print(Panel(content, title="Priority Status", border_style="blue"))
-
-        await run_with_client(get_priority)
-
-    asyncio.run(run_cmd())
-
-
-@priority_group.command(name="on")
-@click.argument("device_identifier")
-@click.option("--minutes", "-m", type=int, default=0, help="Duration in minutes (0=indefinite)")
-@network_option
-@click.pass_context
-def priority_on(
-    ctx: click.Context, device_identifier: str, minutes: int, network_id: Optional[str]
-) -> None:
-    """Enable priority for a device.
-
-    \b
-    Options:
-      --minutes, -m  Duration (0=indefinite)
-    """
-    cli_ctx = apply_options(ctx, network_id=network_id)
-    console = cli_ctx.console
-
-    async def run_cmd() -> None:
-        async def set_priority(client: EeroClient) -> None:
-            # Find device first
-            with cli_ctx.status("Finding device..."):
-                raw_response = await client.get_devices(cli_ctx.network_id)
-
-            devices = extract_devices(raw_response)
-            target = _find_device(devices, device_identifier)
-
-            if not target or not target.get("id"):
-                console.print(f"[red]Device '{device_identifier}' not found[/red]")
-                console.print("[dim]Try: eero device list[/dim]")
-                sys.exit(ExitCode.NOT_FOUND)
-
-            duration_str = f" for {minutes} minutes" if minutes > 0 else " (indefinite)"
-            with cli_ctx.status(f"Prioritizing device{duration_str}..."):
-                # TODO: prioritize_device method not yet implemented in eero-api
-                result = await client.prioritize_device(target["id"], minutes, cli_ctx.network_id)  # type: ignore[attr-defined]
+            with cli_ctx.status(f"{action.capitalize()}ing {device_name}..."):
+                result = await client.pause_device(target["id"], paused, cli_ctx.network_id)
 
             meta = result.get("meta", {}) if isinstance(result, dict) else {}
             if meta.get("code") == 200 or result:
-                console.print(f"[bold green]Device prioritized{duration_str}[/bold green]")
+                console.print(f"[bold green]Device {action}d[/bold green]")
             else:
-                console.print("[red]Failed to prioritize device[/red]")
+                console.print(f"[red]Failed to {action} device[/red]")
                 sys.exit(ExitCode.GENERIC_ERROR)
 
-        await run_with_client(set_priority)
-
-    asyncio.run(run_cmd())
-
-
-@priority_group.command(name="off")
-@click.argument("device_identifier")
-@network_option
-@click.pass_context
-def priority_off(ctx: click.Context, device_identifier: str, network_id: Optional[str]) -> None:
-    """Remove priority from a device."""
-    cli_ctx = apply_options(ctx, network_id=network_id)
-    console = cli_ctx.console
-
-    async def run_cmd() -> None:
-        async def remove_priority(client: EeroClient) -> None:
-            # Find device first
-            with cli_ctx.status("Finding device..."):
-                raw_response = await client.get_devices(cli_ctx.network_id)
-
-            devices = extract_devices(raw_response)
-            target = _find_device(devices, device_identifier)
-
-            if not target or not target.get("id"):
-                console.print(f"[red]Device '{device_identifier}' not found[/red]")
-                console.print("[dim]Try: eero device list[/dim]")
-                sys.exit(ExitCode.NOT_FOUND)
-
-            with cli_ctx.status("Removing priority..."):
-                # TODO: deprioritize_device method not yet implemented in eero-api
-                result = await client.deprioritize_device(target["id"], cli_ctx.network_id)  # type: ignore[attr-defined]
-
-            meta = result.get("meta", {}) if isinstance(result, dict) else {}
-            if meta.get("code") == 200 or result:
-                console.print("[bold green]Priority removed[/bold green]")
-            else:
-                console.print("[red]Failed to remove priority[/red]")
-                sys.exit(ExitCode.GENERIC_ERROR)
-
-        await run_with_client(remove_priority)
+        await run_with_client(toggle_pause)
 
     asyncio.run(run_cmd())

--- a/src/eeroctl/transformers/device.py
+++ b/src/eeroctl/transformers/device.py
@@ -117,8 +117,8 @@ def normalize_device(data: Dict[str, Any]) -> Dict[str, Any]:
         "profile_name": profile_name,
         "profile": profile,
         # Status flags
-        "blocked": data.get("blocked", False),
-        "blacklisted": data.get("blocked", False),  # Alias
+        "blocked": data.get("blacklisted", False),
+        "blacklisted": data.get("blacklisted", False),  # Alias
         "paused": data.get("paused", False),
         "is_guest": data.get("is_guest", False),
         "is_private": data.get("is_private", False),

--- a/tests/cli/commands/test_activity.py
+++ b/tests/cli/commands/test_activity.py
@@ -1,16 +1,50 @@
 """Unit tests for eeroctl.commands.activity module.
 
 Tests cover:
-- activity summary command
-- activity clients command
-- activity history command
-- activity categories command
+- activity history command (get_insights)
+- activity categories command (get_insights, hardcoded blocked)
 """
+
+import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from eeroctl.main import cli
+
+# ---------------------------------------------------------------------------
+# Shared fixture data
+# ---------------------------------------------------------------------------
+
+INSIGHTS_RESPONSE = {
+    "meta": {"code": 200},
+    "data": {
+        "series": [
+            {
+                "insight_type": "inspected",
+                "sum": 42,
+                "values": [{"time": "2026-07-21T00:00:00Z", "value": 42}],
+            }
+        ]
+    },
+}
+
+BLOCKED_INSIGHTS_RESPONSE = {
+    "meta": {"code": 200},
+    "data": {
+        "series": [
+            {
+                "insight_type": "blocked",
+                "sum": 17,
+                "values": [
+                    {"time": "2026-07-20T00:00:00Z", "value": 8},
+                    {"time": "2026-07-21T00:00:00Z", "value": 9},
+                ],
+            }
+        ]
+    },
+}
 
 
 class TestActivityGroup:
@@ -26,11 +60,17 @@ class TestActivityGroup:
         result = runner.invoke(cli, ["activity", "--help"])
 
         assert result.exit_code == 0
-        assert "View network activity" in result.output or "activity" in result.output.lower()
-        assert "summary" in result.output
-        assert "clients" in result.output
+        assert "activity" in result.output.lower()
         assert "history" in result.output
         assert "categories" in result.output
+
+    def test_activity_help_no_summary_or_clients(self, runner):
+        """Test activity help does not mention removed summary/clients subcommands."""
+        result = runner.invoke(cli, ["activity", "--help"])
+
+        assert result.exit_code == 0
+        assert "summary" not in result.output
+        assert "clients" not in result.output
 
     def test_activity_mentions_eero_plus(self, runner):
         """Test activity help mentions Eero Plus requirement."""
@@ -38,38 +78,6 @@ class TestActivityGroup:
 
         assert result.exit_code == 0
         assert "Plus" in result.output or "premium" in result.output.lower()
-
-
-class TestActivitySummary:
-    """Tests for activity summary command."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a CLI runner."""
-        return CliRunner()
-
-    def test_activity_summary_help(self, runner):
-        """Test activity summary shows help."""
-        result = runner.invoke(cli, ["activity", "summary", "--help"])
-
-        assert result.exit_code == 0
-        assert "Show network activity summary" in result.output
-
-
-class TestActivityClients:
-    """Tests for activity clients command."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a CLI runner."""
-        return CliRunner()
-
-    def test_activity_clients_help(self, runner):
-        """Test activity clients shows help."""
-        result = runner.invoke(cli, ["activity", "clients", "--help"])
-
-        assert result.exit_code == 0
-        assert "Show per-client activity" in result.output
 
 
 class TestActivityHistory:
@@ -86,17 +94,112 @@ class TestActivityHistory:
 
         assert result.exit_code == 0
         assert "Show historical activity" in result.output
-        assert "--period" in result.output
+        assert "--start" in result.output
+        assert "--end" in result.output
 
-    def test_activity_history_period_options(self, runner):
-        """Test activity history accepts valid period options."""
-        result = runner.invoke(cli, ["activity", "history", "--help"])
+    def test_activity_history_requires_start(self, runner):
+        """Test activity history exits with code 2 when --start is missing."""
+        result = runner.invoke(cli, ["activity", "history", "--end", "2026-07-22"])
+
+        assert result.exit_code == 2
+        assert "start" in result.output.lower() or "Missing option" in result.output
+
+    def test_activity_history_requires_end(self, runner):
+        """Test activity history exits with code 2 when --end is missing."""
+        result = runner.invoke(cli, ["activity", "history", "--start", "2026-07-01"])
+
+        assert result.exit_code == 2
+        assert "end" in result.output.lower() or "Missing option" in result.output
+
+    def test_activity_history_requires_both_flags(self, runner):
+        """Test activity history exits with code 2 when both --start and --end are missing."""
+        result = runner.invoke(cli, ["activity", "history"])
+
+        assert result.exit_code == 2
+
+    def test_activity_history_renders_table(self, runner):
+        """Test activity history renders a table with insight_type and sum."""
+        mock_client = AsyncMock()
+        mock_client.get_insights = AsyncMock(return_value=INSIGHTS_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                [
+                    "activity",
+                    "history",
+                    "--start",
+                    "2026-07-01",
+                    "--end",
+                    "2026-07-22",
+                ],
+            )
 
         assert result.exit_code == 0
-        assert "hour" in result.output
-        assert "day" in result.output
-        assert "week" in result.output
-        assert "month" in result.output
+        assert "inspected" in result.output
+        assert "42" in result.output
+
+    def test_activity_history_calls_get_insights_with_correct_args(self, runner):
+        """Test activity history passes all required args to get_insights."""
+        mock_client = AsyncMock()
+        mock_client.get_insights = AsyncMock(return_value=INSIGHTS_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            runner.invoke(
+                cli,
+                [
+                    "activity",
+                    "history",
+                    "--start",
+                    "2026-07-01",
+                    "--end",
+                    "2026-07-22",
+                    "--insight-type",
+                    "blocked",
+                    "--cadence",
+                    "weekly",
+                ],
+            )
+
+        mock_client.get_insights.assert_awaited_once()
+        call_kwargs = mock_client.get_insights.call_args[1]
+        assert call_kwargs["start"] == "2026-07-01"
+        assert call_kwargs["end"] == "2026-07-22"
+        assert call_kwargs["insight_type"] == "blocked"
+        assert call_kwargs["cadence"] == "weekly"
+
+    def test_activity_history_json_output_round_trips_envelope(self, runner):
+        """Test activity history --output json round-trips the API envelope."""
+        mock_client = AsyncMock()
+        mock_client.get_insights = AsyncMock(return_value=INSIGHTS_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                [
+                    "--output",
+                    "json",
+                    "activity",
+                    "history",
+                    "--start",
+                    "2026-07-01",
+                    "--end",
+                    "2026-07-22",
+                ],
+            )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        # The CLI wraps in its own envelope; raw data nested inside
+        assert "inspected" in result.output
+        assert "42" in result.output
+        assert parsed is not None
 
 
 class TestActivityCategories:
@@ -112,26 +215,83 @@ class TestActivityCategories:
         result = runner.invoke(cli, ["activity", "categories", "--help"])
 
         assert result.exit_code == 0
-        assert "Show activity" in result.output
-        assert "category" in result.output.lower()
+        assert "blocked" in result.output.lower() or "category" in result.output.lower()
 
+    def test_activity_categories_requires_start(self, runner):
+        """Test activity categories exits with code 2 when --start is missing."""
+        result = runner.invoke(cli, ["activity", "categories", "--end", "2026-07-22"])
 
-class TestActivityFormatBytes:
-    """Tests for the _format_bytes helper function."""
+        assert result.exit_code == 2
 
-    def test_format_bytes_values(self):
-        """Test _format_bytes formats values correctly."""
-        from eeroctl.commands.activity import _format_bytes
+    def test_activity_categories_requires_end(self, runner):
+        """Test activity categories exits with code 2 when --end is missing."""
+        result = runner.invoke(cli, ["activity", "categories", "--start", "2026-07-01"])
 
-        assert "B" in _format_bytes(500)
-        assert "KB" in _format_bytes(2048)
-        assert "MB" in _format_bytes(1024 * 1024 * 5)
-        assert "GB" in _format_bytes(1024 * 1024 * 1024 * 2)
+        assert result.exit_code == 2
 
-    def test_format_bytes_zero(self):
-        """Test _format_bytes handles zero."""
-        from eeroctl.commands.activity import _format_bytes
+    def test_activity_categories_renders_table(self, runner):
+        """Test activity categories renders table with blocked insight data."""
+        mock_client = AsyncMock()
+        mock_client.get_insights = AsyncMock(return_value=BLOCKED_INSIGHTS_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        result = _format_bytes(0)
-        assert "0" in result
-        assert "B" in result
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                [
+                    "activity",
+                    "categories",
+                    "--start",
+                    "2026-07-01",
+                    "--end",
+                    "2026-07-22",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "blocked" in result.output
+        assert "17" in result.output
+
+    def test_activity_categories_hardcodes_blocked_insight_type(self, runner):
+        """Test categories always passes insight_type='blocked' to get_insights."""
+        mock_client = AsyncMock()
+        mock_client.get_insights = AsyncMock(return_value=BLOCKED_INSIGHTS_RESPONSE)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            runner.invoke(
+                cli,
+                [
+                    "activity",
+                    "categories",
+                    "--start",
+                    "2026-07-01",
+                    "--end",
+                    "2026-07-22",
+                ],
+            )
+
+        mock_client.get_insights.assert_awaited_once()
+        call_kwargs = mock_client.get_insights.call_args[1]
+        assert call_kwargs["insight_type"] == "blocked"
+
+    def test_activity_categories_no_insight_type_option(self, runner):
+        """Test activity categories does not expose --insight-type flag."""
+        result = runner.invoke(
+            cli,
+            [
+                "activity",
+                "categories",
+                "--start",
+                "2026-07-01",
+                "--end",
+                "2026-07-22",
+                "--insight-type",
+                "adblock",
+            ],
+        )
+
+        # Should fail because --insight-type is not a valid option for categories
+        assert result.exit_code != 0

--- a/tests/cli/commands/test_device.py
+++ b/tests/cli/commands/test_device.py
@@ -5,8 +5,11 @@ Tests cover:
 - device show command
 - device rename command
 - device block/unblock commands
-- device priority subcommands
+- device pause/unpause commands
+- device transformer regression (blacklisted field)
 """
+
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -33,7 +36,15 @@ class TestDeviceGroup:
         assert "rename" in result.output
         assert "block" in result.output
         assert "unblock" in result.output
-        assert "priority" in result.output
+        assert "pause" in result.output
+        assert "unpause" in result.output
+
+    def test_device_help_no_priority(self, runner):
+        """Test device group help does not mention priority."""
+        result = runner.invoke(cli, ["device", "--help"])
+
+        assert result.exit_code == 0
+        assert "priority" not in result.output
 
 
 class TestDeviceList:
@@ -130,6 +141,39 @@ class TestDeviceBlock:
         assert result.exit_code != 0
         assert "Missing argument" in result.output
 
+    def test_device_block_calls_block_device(self, runner):
+        """Test device block calls client.block_device with correct args."""
+        mock_devices_response = {
+            "meta": {"code": 200},
+            "data": [
+                {
+                    "url": "/2.2/networks/net1/devices/dev1",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "nickname": "MyPhone",
+                    "hostname": "myphone",
+                    "connected": True,
+                    "blacklisted": False,
+                    "paused": False,
+                }
+            ],
+        }
+        mock_block_response = {"meta": {"code": 200}, "data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.get_devices = AsyncMock(return_value=mock_devices_response)
+        mock_client.block_device = AsyncMock(return_value=mock_block_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(cli, ["device", "block", "MyPhone", "--force"])
+
+        assert result.exit_code == 0
+        assert "blocked" in result.output.lower()
+        mock_client.block_device.assert_awaited_once()
+        call_args = mock_client.block_device.call_args
+        assert call_args[0][1] is True  # blocked=True
+
 
 class TestDeviceUnblock:
     """Tests for device unblock command."""
@@ -155,49 +199,217 @@ class TestDeviceUnblock:
         assert "Missing argument" in result.output
 
 
-class TestDevicePriority:
-    """Tests for device priority subcommands."""
+class TestDevicePause:
+    """Tests for device pause command."""
 
     @pytest.fixture
     def runner(self) -> CliRunner:
         """Create a CLI runner."""
         return CliRunner()
 
-    def test_priority_group_help(self, runner):
-        """Test priority group shows help."""
-        result = runner.invoke(cli, ["device", "priority", "--help"])
+    def test_device_pause_help(self, runner):
+        """Test device pause shows help."""
+        result = runner.invoke(cli, ["device", "pause", "--help"])
 
         assert result.exit_code == 0
-        assert "Manage device bandwidth priority" in result.output
-        assert "show" in result.output
-        assert "on" in result.output
-        assert "off" in result.output
+        assert "Pause a device" in result.output
+        assert "--force" in result.output
 
-    def test_priority_show_help(self, runner):
-        """Test priority show shows help."""
-        result = runner.invoke(cli, ["device", "priority", "show", "--help"])
-
-        assert result.exit_code == 0
-        assert "Show priority status" in result.output
-
-    def test_priority_show_requires_argument(self, runner):
-        """Test priority show requires device ID argument."""
-        result = runner.invoke(cli, ["device", "priority", "show"])
+    def test_device_pause_requires_argument(self, runner):
+        """Test device pause requires device ID argument."""
+        result = runner.invoke(cli, ["device", "pause"])
 
         assert result.exit_code != 0
         assert "Missing argument" in result.output
 
-    def test_priority_on_help(self, runner):
-        """Test priority on shows help."""
-        result = runner.invoke(cli, ["device", "priority", "on", "--help"])
+    def test_device_pause_calls_pause_device(self, runner):
+        """Test device pause calls client.pause_device with paused=True."""
+        mock_devices_response = {
+            "meta": {"code": 200},
+            "data": [
+                {
+                    "url": "/2.2/networks/net1/devices/dev1",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "nickname": "MyPhone",
+                    "hostname": "myphone",
+                    "connected": True,
+                    "blacklisted": False,
+                    "paused": False,
+                }
+            ],
+        }
+        mock_pause_response = {"meta": {"code": 200}, "data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.get_devices = AsyncMock(return_value=mock_devices_response)
+        mock_client.pause_device = AsyncMock(return_value=mock_pause_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(cli, ["device", "pause", "MyPhone", "--force"])
 
         assert result.exit_code == 0
-        assert "Enable priority" in result.output
-        assert "--minutes" in result.output
+        assert "paused" in result.output.lower()
+        mock_client.pause_device.assert_awaited_once()
+        call_args = mock_client.pause_device.call_args
+        assert call_args[0][1] is True  # paused=True
 
-    def test_priority_off_help(self, runner):
-        """Test priority off shows help."""
-        result = runner.invoke(cli, ["device", "priority", "off", "--help"])
+    def test_device_pause_passes_network_id(self, runner):
+        """Test device pause passes network_id to pause_device."""
+        mock_devices_response = {
+            "meta": {"code": 200},
+            "data": [
+                {
+                    "url": "/2.2/networks/net1/devices/dev1",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "nickname": "Tablet",
+                    "hostname": "tablet",
+                    "connected": True,
+                    "blacklisted": False,
+                    "paused": False,
+                }
+            ],
+        }
+        mock_pause_response = {"meta": {"code": 200}, "data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.get_devices = AsyncMock(return_value=mock_devices_response)
+        mock_client.pause_device = AsyncMock(return_value=mock_pause_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(
+                cli, ["device", "pause", "Tablet", "--force", "--network-id", "mynet123"]
+            )
 
         assert result.exit_code == 0
-        assert "Remove priority" in result.output
+        call_args = mock_client.pause_device.call_args
+        # Third positional arg is network_id
+        assert call_args[0][2] == "mynet123"
+
+
+class TestDeviceUnpause:
+    """Tests for device unpause command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI runner."""
+        return CliRunner()
+
+    def test_device_unpause_help(self, runner):
+        """Test device unpause shows help."""
+        result = runner.invoke(cli, ["device", "unpause", "--help"])
+
+        assert result.exit_code == 0
+        assert "Unpause a device" in result.output
+        assert "--force" in result.output
+
+    def test_device_unpause_requires_argument(self, runner):
+        """Test device unpause requires device ID argument."""
+        result = runner.invoke(cli, ["device", "unpause"])
+
+        assert result.exit_code != 0
+        assert "Missing argument" in result.output
+
+    def test_device_unpause_calls_pause_device_false(self, runner):
+        """Test device unpause calls client.pause_device with paused=False."""
+        mock_devices_response = {
+            "meta": {"code": 200},
+            "data": [
+                {
+                    "url": "/2.2/networks/net1/devices/dev1",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "nickname": "MyLaptop",
+                    "hostname": "mylaptop",
+                    "connected": True,
+                    "blacklisted": False,
+                    "paused": True,
+                }
+            ],
+        }
+        mock_unpause_response = {"meta": {"code": 200}, "data": {}}
+
+        mock_client = AsyncMock()
+        mock_client.get_devices = AsyncMock(return_value=mock_devices_response)
+        mock_client.pause_device = AsyncMock(return_value=mock_unpause_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("eeroctl.utils.EeroClient", return_value=mock_client):
+            result = runner.invoke(cli, ["device", "unpause", "MyLaptop", "--force"])
+
+        assert result.exit_code == 0
+        assert "unpaused" in result.output.lower()
+        mock_client.pause_device.assert_awaited_once()
+        call_args = mock_client.pause_device.call_args
+        assert call_args[0][1] is False  # paused=False
+
+
+class TestDeviceTransformerRegression:
+    """Regression tests for #106 — blacklisted field in transformer."""
+
+    def test_blacklisted_true_maps_to_blocked_true(self):
+        """Raw dict with blacklisted=True must yield blocked=True and blacklisted=True."""
+        from eeroctl.transformers.device import normalize_device
+
+        raw = {
+            "url": "/2.2/networks/net1/devices/dev1",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "blacklisted": True,
+            "paused": False,
+            "connected": True,
+        }
+        result = normalize_device(raw)
+
+        assert result["blocked"] is True
+        assert result["blacklisted"] is True
+
+    def test_blacklisted_false_maps_to_blocked_false(self):
+        """Raw dict with blacklisted=False must yield blocked=False."""
+        from eeroctl.transformers.device import normalize_device
+
+        raw = {
+            "url": "/2.2/networks/net1/devices/dev1",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "blacklisted": False,
+            "paused": False,
+            "connected": True,
+        }
+        result = normalize_device(raw)
+
+        assert result["blocked"] is False
+        assert result["blacklisted"] is False
+
+    def test_missing_blacklisted_defaults_to_false(self):
+        """Raw dict with no blacklisted key must default blocked/blacklisted to False."""
+        from eeroctl.transformers.device import normalize_device
+
+        raw = {
+            "url": "/2.2/networks/net1/devices/dev1",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "paused": False,
+            "connected": True,
+        }
+        result = normalize_device(raw)
+
+        assert result["blocked"] is False
+        assert result["blacklisted"] is False
+
+    def test_no_spurious_blocked_field_is_not_used(self):
+        """A raw dict with only 'blocked' (wrong field) must NOT propagate as blocked=True."""
+        from eeroctl.transformers.device import normalize_device
+
+        raw = {
+            "url": "/2.2/networks/net1/devices/dev1",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "blocked": True,  # wrong SDK field; SDK uses 'blacklisted'
+            "paused": False,
+            "connected": True,
+        }
+        result = normalize_device(raw)
+
+        # 'blacklisted' key absent → blocked and blacklisted should both be False
+        assert result["blocked"] is False
+        assert result["blacklisted"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -352,21 +352,21 @@ wheels = [
 
 [[package]]
 name = "eero-api"
-version = "5.0.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "keyring" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/96/3290bc0f2d21a8a2659d7fc72db702e5daa25eeb595bdef03d74785e3981/eero_api-5.0.0.tar.gz", hash = "sha256:8773873721b57329275bba1ee7cfe56dbc589fe0cf4aa6f5200ddd669b0857de", size = 43266, upload-time = "2026-06-11T13:46:34.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c6/46d80730e3df36298b1d566bbd87ecad77fd17aa01aa9e9830f35b7f129d/eero_api-6.0.0.tar.gz", hash = "sha256:3f5e6d84127d3f34992d9a5c7cd4766d100ddd3bfd6cf0b58c6c3f2c720bd5d0", size = 47584, upload-time = "2026-07-22T18:50:44.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/af/d86b0dfb5bff0c29a30c963c6da46de0385ca738f9c23693b9ec7ba7407e/eero_api-5.0.0-py3-none-any.whl", hash = "sha256:50d71940f892dea6782f45e445db7a15cb4892f43b763ec12e4c0a1a0aa0a333", size = 60274, upload-time = "2026-06-11T13:46:33.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/26/05eab414cc4c19fcce137c27fb3ea2871b8d1e38d06c4f7c784644f008c8/eero_api-6.0.0-py3-none-any.whl", hash = "sha256:fe0b5aa2285ba719c9893dfdd2010df49f2ee67bada596af8852e9b7a2b5bfc8", size = 64899, upload-time = "2026-07-22T18:50:43.238Z" },
 ]
 
 [[package]]
 name = "eeroctl"
-version = "2.21.1"
+version = "2.21.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -390,7 +390,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "eero-api", specifier = "==5.0.0" },
+    { name = "eero-api", specifier = "==6.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },

--- a/wiki/CLI-Reference.md
+++ b/wiki/CLI-Reference.md
@@ -77,10 +77,8 @@ eero
 │   ├── rename <id> --name <name>
 │   ├── block <id>
 │   ├── unblock <id>
-│   └── priority     # Bandwidth priority
-│       ├── show
-│       ├── on [--minutes <n>]
-│       └── off
+│   ├── pause <id>
+│   └── unpause <id>
 │
 ├── profile          # User profile management
 │   ├── list         # List all profiles
@@ -96,9 +94,8 @@ eero
 │       └── set
 │
 ├── activity         # Activity data (Eero Plus)
-│   ├── clients      # Client activity
-│   ├── history      # Activity history
-│   └── categories   # Traffic categories
+│   ├── history      # Activity history (requires --start and --end)
+│   └── categories   # Blocked-traffic categories (requires --start and --end)
 │
 ├── troubleshoot     # Troubleshooting tools
 │   ├── status       # Network health status

--- a/wiki/Usage-Examples.md
+++ b/wiki/Usage-Examples.md
@@ -118,8 +118,14 @@ eero device rename "00:11:22:33:44:55" --name "Work Laptop"
 # Block a device
 eero device block "Smart TV" --force
 
-# Prioritize a device for 30 minutes
-eero device priority on "Gaming PC" --minutes 30
+# Unblock a device
+eero device unblock "Smart TV" --force
+
+# Pause internet access for a device
+eero device pause "Kids Tablet" --force
+
+# Unpause internet access for a device
+eero device unpause "Kids Tablet"
 ```
 
 ---
@@ -141,6 +147,27 @@ eero profile apps block "Kids" TikTok YouTube
 
 # Unblock applications
 eero profile apps unblock "Kids" YouTube
+```
+
+---
+
+## Activity (Eero Plus)
+
+```bash
+# Show historical inspected-traffic data for a date range
+eero activity history --start 2026-07-01 --end 2026-07-22
+
+# Weekly cadence, blocked insight type
+eero activity history --start 2026-07-01 --end 2026-07-22 --insight-type blocked --cadence weekly
+
+# Show blocked-traffic categories for a date range
+eero activity categories --start 2026-07-01 --end 2026-07-22
+
+# Weekly cadence for categories
+eero activity categories --start 2026-07-01 --end 2026-07-22 --cadence weekly
+
+# JSON output for scripting
+eero --output json activity history --start 2026-07-01 --end 2026-07-22
 ```
 
 ---


### PR DESCRIPTION
## Summary

Bumps `eero-api` to `6.0.0` and repairs downstream breakage across `device` and `activity` command groups.

- **fix(#106):** `device` transformer now reads the correct `blacklisted` SDK field instead of the nonexistent `blocked` field, so `eero device show` reflects the actual blacklist state.
- **fix(#107):** Removed the entire `device priority` group (`show`/`on`/`off`). The underlying priority endpoint is a server-side no-op and the SDK methods are deprecated for removal.
- **feat(#108):** New `eero device pause` / `eero device unpause` commands, mirroring the block/unblock pattern (safety-rail confirmation, `--force`, `--non-interactive`).
- **fix(#109):** Rewrote `eero activity history` and `eero activity categories` on top of `client.get_insights` (required `--start` / `--end`, plus `--insight-type` and `--cadence`). Dropped `activity summary` and `activity clients` — they depended on `/activity` endpoints that Eero removed; equivalents will return via #46 on `get_data_usage`.

## Files changed

- `pyproject.toml` — pin `eero-api==6.0.0` (supersedes renovate PR #102)
- `src/eeroctl/transformers/device.py` — read `blacklisted`
- `src/eeroctl/commands/device.py` — remove priority group, add pause/unpause
- `src/eeroctl/commands/activity.py` — rewrite on `get_insights`
- `tests/cli/commands/test_device.py`, `tests/cli/commands/test_activity.py` — dropped priority/summary/clients tests, added pause/unpause + insights coverage + transformer regression test (461 tests pass, +15 net)
- `wiki/CLI-Reference.md`, `wiki/Usage-Examples.md` — updated docs

## Test plan

- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/ -q` — 461 passed, 1 skipped
- [ ] Live-verify `eero device pause`/`unpause` against a real network
- [ ] Live-verify `eero activity history --start ... --end ...` returns the expected `series[]` envelope

Closes #106
Closes #107
Closes #108
Closes #109